### PR TITLE
Expanding syntax coverage of OutputVisitor

### DIFF
--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -92,7 +92,7 @@ class OutputVisitor {
     return toOperatorExpression(path, state, this);
   }
   AND(path, state) {
-    addToSyntax(state, 'and');
+    addToSyntax(state, ' and');
   }
   Arguments({get}, state) {
     const propertiesSyntax = toSyntax(get('param'), this);
@@ -135,12 +135,13 @@ class OutputVisitor {
   DotMemberExpression(path, state) {
   }
   ElseStatement(path, state) {
-    addToSyntax(state, 'else');
+    addToSyntax(state, 'else ');
   }
   ElseIfStatement({get}, state) {
     const test = toSyntax(get('test'), this);
     const body = toSyntax(get('body'), this);
-
+    //NOTE: Brightscript documentation states that "then" is an optional keyword for
+    //      IF, ELSEIF, THEN, ENDIF block
     addToSyntax(state, 'else if', test, body);
     return false;
   }
@@ -312,7 +313,7 @@ class OutputVisitor {
     addToSyntax(state, 'stop');
   }  
   TypeAnnotation({node:{value}}, state) {
-    addToSyntax(state, 'as', value);    
+    addToSyntax(state, ' as', value);
   }
   UnaryExpression(path, state) {
   }

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -224,6 +224,9 @@ class OutputVisitor {
   LESS_THAN_EQUAL(path, state) {
     addToSyntax(state, '<=');
   }
+  LibraryStatement(path, state) {
+    addToSyntax(state, 'library');
+  }
   Literal({node:{raw, value}}, state) {
     addToSyntax(state, value);
   }

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -159,6 +159,14 @@ class OutputVisitor {
   EmptyStatement(path, state) {
     addToSyntax(state, '\n');
   }
+  ForEachStatement(path, state) {
+    const {get} = path;
+    const counter = toSyntax(get('counter'), this);
+    const countExpression = toSyntax(get('countExpression'), this);
+    const body = toSyntax(get('body'), this);
+    addToSyntax(state, 'for each', counter, 'in', countExpression, body, 'end for');
+    return false;
+  }
   ForStatement(path, state) {
     const {get} = path;
     const test = toSyntax(get('test'), this);

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -153,6 +153,9 @@ class OutputVisitor {
   EQUAL({node: {value}}, state) {
     addToSyntax(state, '=');
   }
+  EXIT_FOR(path, state) {
+    addToSyntax(state, 'exit for')
+  }
   EXIT_WHILE(path, state) {
     addToSyntax(state, 'exit while');
   }
@@ -173,8 +176,10 @@ class OutputVisitor {
     const body = toSyntax(get('body'), this);
     const counter = toSyntax(get('counter'), this);
     const init = toSyntax(get('init'), this);
+    const update = toSyntax(get('update'), this);
+    const explicitStep = update ? `step ${update}` : undefined;
 
-    addToSyntax(state, 'For', counter, (counter && init.length)?'=':'', init, 'to', test, body, 'end For');
+    addToSyntax(state, 'for', counter, (counter && init.length)?'=':'', init, 'to', test, explicitStep, body, 'end for');
     return false;
   }
   FunctionDeclaration(path, state) {

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -100,10 +100,12 @@ class OutputVisitor {
     return false;
   }
   ArrayElement(path, state) {
+    const element = toSyntax(path.get('value'), this);
+    addToSyntax(state, element);
+    return false;
   }
   ArrayExpression({get}, state) {
-    const elements = toSyntax(get('elements'), this);
-    addToSyntax(state, '[', withComma(elements), ']');
+    addToSyntax(state, '[', toSyntax(get('elements'), this), ']');
     return false;  
   }
   AssignmentExpression(path, state) {

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -202,14 +202,17 @@ class OutputVisitor {
   Identifier({node:{name}}, state) {
     addToSyntax(state, name);
   }
-  IfStatement({get}, state) {
+  IfStatement(path, state) {
+    const {get, node:{consequent: {type}}} = path;
     //logic from here needs to apply to else if as well... refactor?
     const test = toSyntax(get('test'), this);
     const consequent = toSyntax(get('consequent'), this);
     const alternate = toSyntax(get('alternate'), this);
-    const blockForm = (alternate && alternate.length) || consequent.includes('\n');
+    const blockForm = type === 'BlockStatement';
     //still need to fix this.... bad way to determine block form
 
+    //NOTE: Brightscript documentation states that "then" is an optional keyword for
+    //      IF, ELSEIF, THEN, ENDIF block
     addToSyntax(state, 'if', test, consequent, withNothing(alternate), blockForm?'end if':'');
     return false;
   }

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -218,7 +218,9 @@ class OutputVisitor {
   }
   LabeledStatement(path, state) {
     const {node: {label: {name}}} = path;
-    addToSyntax(state, name, ':')
+    //TODO: Seems to be treating the line following the label as the body of the label statement.
+    const body = toSyntax(path.get('body'), this);
+    addToSyntax(state, name, ':\n', body)
     return false;
   }
   LESS_THAN(path, state) {

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -220,6 +220,9 @@ class OutputVisitor {
     addToSyntax(state, 'if', test, consequent, withNothing(alternate), blockForm?'end if':'');
     return false;
   }
+  INCREMENT(path, state) {
+    addToSyntax(state, '++');
+  }
   LabeledStatement(path, state) {
     const {node: {label: {name}}} = path;
     //TODO: Seems to be treating the line following the label as the body of the label statement.

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -171,7 +171,7 @@ class OutputVisitor {
     const counter = toSyntax(get('counter'), this);
     const countExpression = toSyntax(get('countExpression'), this);
     const body = toSyntax(get('body'), this);
-    addToSyntax(state, 'for each', counter, 'in', countExpression, body, 'end for');
+    addToSyntax(state, 'for each', counter, 'in ', countExpression, body, 'end for');
     return false;
   }
   ForStatement(path, state) {
@@ -327,16 +327,13 @@ class OutputVisitor {
   PERIOD(path, state) {
     addToSyntax(state, '.');
   }
-  PrintStatement(path, state) {
-    const {get} = path
+  PrintStatement({get}, state) {
     const value = toSyntax(get('value'), this);
 
-    // TODO: Is there a reason why this is a ? instead of 'print'?
     addToSyntax(state, '?', withSemiColon(value));
     return false;
   }
-  PostfixExpression(path, state) {
-    const {get} = path;
+  PostfixExpression({get}, state) {
     const arg = toSyntax(get('argument'), this);
     const operator = toSyntax(get('operator'), this);
     addToSyntax(state, arg, operator);
@@ -344,7 +341,7 @@ class OutputVisitor {
   }
   Program(path, state) {
   }
-  Property({get, node}, state) {
+  Property({get}, state) {
     const key = toSyntax(get('key'), this);
     const value = toSyntax(get('value'), this);
 

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -105,7 +105,8 @@ class OutputVisitor {
     return false;
   }
   ArrayExpression({get}, state) {
-    addToSyntax(state, '[', toSyntax(get('elements'), this), ']');
+    const elements = toSyntax(get('elements'), this);
+    addToSyntax(state, '[', elements, ']');
     return false;
   }
   AssignmentExpression(path, state) {
@@ -130,6 +131,9 @@ class OutputVisitor {
     const {node: {value}} = path;
     addToSyntax(state, "'", value, "\n");
     return false;
+  }
+  DECREMENT(path, state) {
+    addToSyntax(state, '--');
   }
   DimStatement(path, state) {
     addToSyntax(state, 'dim');
@@ -257,6 +261,27 @@ class OutputVisitor {
     addToSyntax(state, '{', withComma(properties), '}');
     return false;
   }
+  OP_ASSIGNMENT_ADD(path, state) {
+    addToSyntax(state, '+=');
+  }
+  OP_ASSIGNMENT_SUBTRACT(path, state) {
+    addToSyntax(state, '-=');
+  }
+  OP_ASSIGNMENT_DIVISION(path, state) {
+    addToSyntax(state, '/=');
+  }
+  OP_ASSIGNMENT_INTEGER_DIVISION(path, state) {
+    addToSyntax(state, '\\=');
+  }
+  OP_ASSIGNMENT_MULTIPLY(path, state) {
+    addToSyntax(state, '*=');
+  }
+  OP_ASSIGNMENT_BITSHIFT_LEFT(path, state) {
+    addToSyntax(state, '<<=');
+  }
+  OP_ASSIGNMENT_BITSHIFT_RIGHT(path, state) {
+    addToSyntax(state, '>>=');
+  }
   OP_MINUS(path, state) {
     addToSyntax(state, '-');
   }
@@ -305,6 +330,13 @@ class OutputVisitor {
 
     // TODO: Is there a reason why this is a ? instead of 'print'?
     addToSyntax(state, '?', withSemiColon(value));
+    return false;
+  }
+  PostfixExpression(path, state) {
+    const {get} = path;
+    const arg = toSyntax(get('argument'), this);
+    const operator = toSyntax(get('operator'), this);
+    addToSyntax(state, arg, operator);
     return false;
   }
   Program(path, state) {

--- a/visitors/OutputVisitor.js
+++ b/visitors/OutputVisitor.js
@@ -106,7 +106,7 @@ class OutputVisitor {
   }
   ArrayExpression({get}, state) {
     addToSyntax(state, '[', toSyntax(get('elements'), this), ']');
-    return false;  
+    return false;
   }
   AssignmentExpression(path, state) {
     return toOperatorExpression(path, state, this);
@@ -117,7 +117,7 @@ class OutputVisitor {
   BlockStatement({get}, state) {
     const body = toSyntax(get('body'), this);
     addToSyntax(state, '\n', withNothing(body), '\n');
-    return false;  
+    return false;
   }
   CallExpression({get}, state) {
     const callee = toSyntax(get('callee'), this);
@@ -283,7 +283,7 @@ class OutputVisitor {
     const type = toSyntax(get('TypeAnnotation'), this);
     const value = toSyntax(get('value'), this);
 
-    addToSyntax(state, name, type, value?`=${value}`:'');
+    addToSyntax(state, name, value?`=${value}`:'', type);
     return false;
   }
   ParameterList({get}, state) {
@@ -321,13 +321,16 @@ class OutputVisitor {
   }
   ReturnStatement(path, state) {
     //when we are not in a block, we need to have a space before us
-    addToSyntax(state, 'return');
+    const returnExpression = toSyntax(path.get('argument'), this);
+    const trailingComments = toSyntax(path.get('trailingComments'), this);
+    addToSyntax(state, 'return', returnExpression, ' ', trailingComments);
+    return false;
   }
   SubDeclaration(path, state) {
     return toSubFuncDefinition('sub')(path, state, this);
   }
   STRING_LITERAL({node: {loc: {source}}}, state) {
-    addToSyntax(state, source);    
+    addToSyntax(state, source);
   }
   StopStatement(path, state) {
     addToSyntax(state, 'stop', '\n')


### PR DESCRIPTION
I believe most of the missing syntax is covered in these changes but I am still going through documentation, examples, and writing test cases to verify that nothing is missing.